### PR TITLE
Add support for entitlement management access package assignment requests

### DIFF
--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -96,6 +96,7 @@ type Test struct {
 	Token  *oauth2.Token
 
 	AccessPackageAssignmentPolicyClient       *msgraph.AccessPackageAssignmentPolicyClient
+	AccessPackageAssignmentRequestClient      *msgraph.AccessPackageAssignementRequestClient
 	AccessPackageCatalogClient                *msgraph.AccessPackageCatalogClient
 	AccessPackageClient                       *msgraph.AccessPackageClient
 	AccessPackageResourceClient               *msgraph.AccessPackageResourceClient

--- a/internal/test/testing.go
+++ b/internal/test/testing.go
@@ -184,6 +184,11 @@ func NewTest(t *testing.T) (c *Test) {
 	c.AccessPackageAssignmentPolicyClient.BaseClient.Endpoint = c.Connections["default"].AuthConfig.Environment.MsGraph.Endpoint
 	c.AccessPackageAssignmentPolicyClient.BaseClient.RetryableClient.RetryMax = retry
 
+	c.AccessPackageAssignmentRequestClient = msgraph.NewAccessPackageAssignmentRequestClient(c.Connections["default"].AuthConfig.TenantID)
+	c.AccessPackageAssignmentRequestClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
+	c.AccessPackageAssignmentRequestClient.BaseClient.Endpoint = c.Connections["default"].AuthConfig.Environment.MsGraph.Endpoint
+	c.AccessPackageAssignmentRequestClient.BaseClient.RetryableClient.RetryMax = retry
+
 	c.AccessPackageCatalogClient = msgraph.NewAccessPackageCatalogClient(c.Connections["default"].AuthConfig.TenantID)
 	c.AccessPackageCatalogClient.BaseClient.Authorizer = c.Connections["default"].Authorizer
 	c.AccessPackageCatalogClient.BaseClient.Endpoint = c.Connections["default"].AuthConfig.Environment.MsGraph.Endpoint

--- a/msgraph/accesspackageassignementrequest.go
+++ b/msgraph/accesspackageassignementrequest.go
@@ -1,0 +1,168 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/manicminer/hamilton/odata"
+)
+
+type AccessPackageAssignementRequestClient struct {
+	BaseClient Client
+}
+
+func NewAccessPackageAssignmentRequestClient(tenantId string) *AccessPackageAssignementRequestClient {
+	return &AccessPackageAssignementRequestClient{
+		BaseClient: NewClient(Version10, tenantId),
+	}
+}
+
+// List will list all access package assignment requests
+func (c *AccessPackageAssignementRequestClient) List(ctx context.Context, query odata.Query) (*[]AccessPackageAssignmentRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		DisablePaging:    query.Top > 0,
+		ValidStatusCodes: []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      "/identityGovernance/entitlementManagement/assignmentRequests",
+			Params:      query.Values(),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AccessPackageAssignementRequestClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var data struct {
+		AccessPacakgeAssignmentRequest []AccessPackageAssignmentRequest `json:"value"`
+	}
+	if err := json.Unmarshal(respBody, &data); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &data.AccessPacakgeAssignmentRequest, status, nil
+}
+
+// Get will get an Access Package request
+func (c *AccessPackageAssignementRequestClient) Get(ctx context.Context, id string) (*AccessPackageAssignmentRequest, int, error) {
+	resp, status, _, err := c.BaseClient.Get(ctx, GetHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusOK},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/assignmentRequests/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AccessPackageAssignementRequestClient.BaseClient.Get(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var accessPackageAssignmentRequest AccessPackageAssignmentRequest
+	if err := json.Unmarshal(respBody, &accessPackageAssignmentRequest); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &accessPackageAssignmentRequest, status, nil
+}
+
+// Create will create an access package request
+func (c *AccessPackageAssignementRequestClient) Create(ctx context.Context, accessPackageAssignementRequest AccessPackageAssignmentRequest) (*AccessPackageAssignmentRequest, int, error) {
+	var status int
+	body, err := json.Marshal(accessPackageAssignementRequest)
+	if err != nil {
+		return nil, status, fmt.Errorf("json.Marshal(): %v", err)
+	}
+
+	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		Body:             body,
+		ValidStatusCodes: []int{http.StatusCreated},
+		Uri: Uri{
+			Entity:      "/identityGovernance/entitlementManagement/assignmentRequests",
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return nil, status, fmt.Errorf("AccessPackageAssignementRequestClient.BaseClient.Post(): %v", err)
+	}
+
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status, fmt.Errorf("io.ReadAll(): %v", err)
+	}
+
+	var newAccessPackageAssignmentRequest AccessPackageAssignmentRequest
+	if err := json.Unmarshal(respBody, &newAccessPackageAssignmentRequest); err != nil {
+		return nil, status, fmt.Errorf("json.Unmarshal(): %v", err)
+	}
+
+	return &newAccessPackageAssignmentRequest, status, nil
+}
+
+// Delete will delete an access package request
+func (c *AccessPackageAssignementRequestClient) Delete(ctx context.Context, id string) (int, error) {
+	_, status, _, err := c.BaseClient.Delete(ctx, DeleteHttpRequestInput{
+		ConsistencyFailureFunc: RetryOn404ConsistencyFailureFunc,
+		ValidStatusCodes:       []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/assignmentRequests/%s", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AccessPackageAssignmentPolicyClient.BaseClient.Delete(): %v", err)
+	}
+
+	return status, nil
+
+}
+
+// Cancel will cancel a request is in a cancellable state
+func (c *AccessPackageAssignementRequestClient) Cancel(ctx context.Context, id string) (int, error) {
+	var status int
+
+	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusNoContent},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/assignmentRequests/%s/cancel", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AccessPackageAssignementRequestClient.BaseClient.Post(): %v", err)
+	}
+
+	return status, nil
+}
+
+// Reprocess re-processes an access package assignment request
+func (c *AccessPackageAssignementRequestClient) Reprocess(ctx context.Context, id string) (int, error) {
+	var status int
+
+	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
+		ValidStatusCodes: []int{http.StatusAccepted},
+		Uri: Uri{
+			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/assignmentRequests/%s/reprocess", id),
+			HasTenantId: true,
+		},
+	})
+	if err != nil {
+		return status, fmt.Errorf("AccessPackageAssignementRequestClient.BaseClient.Post(): %v", err)
+	}
+
+	return status, nil
+}

--- a/msgraph/accesspackageassignementrequest.go
+++ b/msgraph/accesspackageassignementrequest.go
@@ -89,7 +89,7 @@ func (c *AccessPackageAssignementRequestClient) Create(ctx context.Context, acce
 
 	resp, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
 		Body:             body,
-		ValidStatusCodes: []int{http.StatusCreated},
+		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      "/identityGovernance/entitlementManagement/assignmentRequests",
 			HasTenantId: true,

--- a/msgraph/accesspackageassignementrequest.go
+++ b/msgraph/accesspackageassignementrequest.go
@@ -136,7 +136,7 @@ func (c *AccessPackageAssignementRequestClient) Cancel(ctx context.Context, id s
 	var status int
 
 	_, status, _, err := c.BaseClient.Post(ctx, PostHttpRequestInput{
-		ValidStatusCodes: []int{http.StatusNoContent},
+		ValidStatusCodes: []int{http.StatusOK},
 		Uri: Uri{
 			Entity:      fmt.Sprintf("/identityGovernance/entitlementManagement/assignmentRequests/%s/cancel", id),
 			HasTenantId: true,

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -54,7 +54,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 	})
 
 	// Adding a sleep, original testing showed the policy could not find the user applied as an approver. Adding a sleep solved this issue.
-	// Originally attempted a get of user after create but didn't help.
+	// Originally attempted a get of user after create but didn't help. Seems to be an eventual consistency issue
 	time.Sleep(time.Second * 10)
 
 	// Create Assignment Policy
@@ -188,7 +188,7 @@ func testAccessPackageAssignmentRequestClient_Cancel(t *testing.T, c *test.Test,
 	if err != nil {
 		t.Fatalf("AccessPackageAssignmentRequestClient.Cancel(): %v", err)
 	}
-	if status != 204 {
+	if status != 200 {
 		t.Fatalf("AccessPackageAssignmentRequestClient.Cancel(): invalid status: %d", status)
 	}
 }

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -154,12 +154,16 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 	// 	},
 	// }
 
+	accessPackageGet := testAccessPackageClient_Get(t, c, *accessPackage.ID)
+	userGet := testUsersClient_Get(t, c, *user.Id)
+	policyGetID := testAccessPackageAssignmentPolicyClient_Get(t, c, *accessPackageAssignmentPolicy.ID)
+
 	ap := testAccessPackageAssignmentRequestClient_Create(t, c, msgraph.AccessPackageAssignmentRequest{
 		RequestType: utils.StringPtr(msgraph.AccessPacakgeRequestTypeAdminAdd),
 		AccessPackageAssignment: &msgraph.AccessPackageAssignment{
-			TargetID:            user.Id,
-			AssignementPolicyID: accessPackageAssignmentPolicy.ID,
-			AccessPackageID:     accessPackage.ID,
+			TargetID:            userGet.Id,
+			AssignementPolicyID: policyGetID.ID,
+			AccessPackageID:     accessPackageGet.ID,
 		},
 	})
 	testAccessPacakgeAssignmentRequestClient_Delete(t, c, *ap.ID)

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -53,6 +53,10 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 		},
 	})
 
+	// Adding a sleep, original testing showed the policy could not find the user applied as an approver. Adding a sleep solved this issue.
+	// Originally attempted a get of user after create but didn't help.
+	time.Sleep(time.Second * 10)
+
 	// Create Assignment Policy
 	accessPackageAssignmentPolicy := testAccessPackageAssignmentPolicyClient_Create(t, c, msgraph.AccessPackageAssignmentPolicy{
 		AccessPackageId: accessPackage.ID,

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -65,13 +65,6 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 			ReviewerType:                    msgraph.AccessReviewReviewerTypeSelf,
 			IsAccessRecommendationEnabled:   utils.BoolPtr(true),
 			IsApprovalJustificationRequired: utils.BoolPtr(true),
-			Reviewers: &[]msgraph.UserSet{
-				{
-					ODataType: utils.StringPtr(odata.TypeUser),
-					IsBackup:  utils.BoolPtr(false),
-					ID:        approverUser.Id,
-				},
-			},
 		},
 		DisplayName: utils.StringPtr(fmt.Sprintf("Test-AP-Policy-Assignment-%s", c.RandomString)),
 		Description: utils.StringPtr("Test AP Policy Assignment Description"),
@@ -91,9 +84,10 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 					IsEscalationEnabled:             utils.BoolPtr(false),
 					PrimaryApprovers: &[]msgraph.UserSet{
 						{
-							ODataType: utils.StringPtr(odata.TypeUser),
-							IsBackup:  utils.BoolPtr(false),
-							ID:        approverUser.Id,
+							ODataType:   utils.StringPtr(odata.TypeSingleUser),
+							Description: utils.StringPtr("approver"),
+							IsBackup:    utils.BoolPtr(false),
+							ID:          approverUser.Id,
 						},
 					},
 				},

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -45,9 +45,9 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 
 	approverUser := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
-		DisplayName:       utils.StringPtr("test-user-approver"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-approver-%s", c.RandomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-approver-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		DisplayName:       utils.StringPtr("test-approver"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-approver-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-approver-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
 		PasswordProfile: &msgraph.UserPasswordProfile{
 			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
@@ -87,7 +87,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 							ODataType:   utils.StringPtr(odata.TypeSingleUser),
 							Description: utils.StringPtr("approver"),
 							IsBackup:    utils.BoolPtr(false),
-							ID:          approverUser.Id,
+							ID:          approverUser.ID(),
 						},
 					},
 				},
@@ -98,7 +98,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 	ap := testAccessPackageAssignmentRequestClient_Create(t, c, msgraph.AccessPackageAssignmentRequest{
 		RequestType: utils.StringPtr(msgraph.AccessPacakgeRequestTypeAdminAdd),
 		AccessPackageAssignment: &msgraph.AccessPackageAssignment{
-			TargetID:            user.Id,
+			TargetID:            user.ID(),
 			AssignementPolicyID: accessPackageAssignmentPolicy.ID,
 			AccessPackageID:     accessPackage.ID,
 		},
@@ -107,7 +107,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 	ap2 := testAccessPackageAssignmentRequestClient_Create(t, c, msgraph.AccessPackageAssignmentRequest{
 		RequestType: utils.StringPtr(msgraph.AccessPacakgeRequestTypeAdminAdd),
 		AccessPackageAssignment: &msgraph.AccessPackageAssignment{
-			TargetID:            user2.Id,
+			TargetID:            user2.ID(),
 			AssignementPolicyID: accessPackageAssignmentPolicy.ID,
 			AccessPackageID:     accessPackage.ID,
 		},

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -2,6 +2,7 @@ package msgraph_test
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -68,6 +69,8 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 			AccessPackageID:     accessPackage.ID,
 		},
 	}
+
+	log.Println(accessPackageAssignementRequest)
 
 	ap := testAccessPackageAssignmentRequestClient_Create(t, c, accessPackageAssignementRequest)
 	testAccessPacakgeAssignmentRequestClient_Delete(t, c, *ap.ID)

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -84,6 +84,20 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 			IsApprovalRequiredForExtension:   utils.BoolPtr(false),
 			IsRequestorJustificationRequired: utils.BoolPtr(false),
 			ApprovalMode:                     msgraph.ApprovalModeSingleStage,
+			ApprovalStages: &[]msgraph.ApprovalStage{
+				{
+					ApprovalStageTimeOutInDays:      utils.Int32Ptr(7),
+					IsApproverJustificationRequired: utils.BoolPtr(false),
+					IsEscalationEnabled:             utils.BoolPtr(false),
+					PrimaryApprovers: &[]msgraph.UserSet{
+						{
+							ODataType: utils.StringPtr(odata.TypeSingleUser),
+							IsBackup:  utils.BoolPtr(true),
+							ID:        utils.StringPtr(*approverUser.Id),
+						},
+					},
+				},
+			},
 		},
 	})
 

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -67,7 +67,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 			IsApprovalJustificationRequired: utils.BoolPtr(true),
 			Reviewers: &[]msgraph.UserSet{
 				{
-					ODataType: utils.StringPtr(odata.TypeSingleUser),
+					ODataType: utils.StringPtr(odata.TypeUser),
 					IsBackup:  utils.BoolPtr(false),
 					ID:        approverUser.Id,
 				},
@@ -91,7 +91,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 					IsEscalationEnabled:             utils.BoolPtr(false),
 					PrimaryApprovers: &[]msgraph.UserSet{
 						{
-							ODataType: utils.StringPtr(odata.TypeSingleUser),
+							ODataType: utils.StringPtr(odata.TypeUser),
 							IsBackup:  utils.BoolPtr(false),
 							ID:        approverUser.Id,
 						},

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -123,11 +123,11 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 	testAccessPackageAssignmentRequestClient_Cancel(t, c, *ap.ID)
 	testAccessPackageAssignmentRequestClient_Cancel(t, c, *ap2.ID)
 
-	_ = testAccessPackageAssignmentRequestClient_Get(t, c, *ap.ID)
+	testAccessPackageAssignmentRequestClient_Get(t, c, *ap.ID)
 
+	//Cleanup
 	deleteWhenPossible(t, c, ap)
 	deleteWhenPossible(t, c, ap2)
-	//Cleanup
 	testAccessPackageAssignmentPolicyClient_Delete(t, c, *accessPackageAssignmentPolicy.ID)
 	testAccessPackage_Delete(t, c, *accessPackage.ID)
 	testAccessPackageCatalog_Delete(t, c, accessPackageCatalog)
@@ -165,7 +165,7 @@ func testAccessPackageAssignmentRequestClient_Create(t *testing.T, c *test.Test,
 	return request
 }
 
-func testAccessPackageAssignmentRequestClient_Get(t *testing.T, c *test.Test, id string) (request *msgraph.AccessPackageAssignmentRequest) {
+func testAccessPackageAssignmentRequestClient_Get(t *testing.T, c *test.Test, id string) {
 	request, status, err := c.AccessPackageAssignmentRequestClient.Get(c.Context, id)
 	if err != nil {
 		t.Fatalf("AccessPackageAssignementRequestClient.Get(): %v", err)
@@ -179,8 +179,6 @@ func testAccessPackageAssignmentRequestClient_Get(t *testing.T, c *test.Test, id
 	if request.ID == nil {
 		t.Fatal("AccessPackageAssignementRequestClient.Get(): AccessPackageAssignmentRequest.ID was nil")
 	}
-	return request
-
 }
 
 func testAccessPackageAssignmentRequestClient_Cancel(t *testing.T, c *test.Test, id string) {

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -23,6 +23,16 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 
 	currentTime := time.Now()
 
+	approverUser := testUsersClient_Create(t, c, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-approver"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-approver-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-approver-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
+		},
+	})
+
 	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
 		DisplayName:       utils.StringPtr("test-user"),
@@ -42,19 +52,6 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
 		},
 	})
-
-	approverUser := testUsersClient_Create(t, c, msgraph.User{
-		AccountEnabled:    utils.BoolPtr(true),
-		DisplayName:       utils.StringPtr("test-approver"),
-		MailNickname:      utils.StringPtr(fmt.Sprintf("test-approver-%s", c.RandomString)),
-		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-approver-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
-		PasswordProfile: &msgraph.UserPasswordProfile{
-			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
-		},
-	})
-
-	// Making a get after create to try and protect against eventual consistency issue
-	approver := testUsersClient_Get(t, c, *approverUser.ID())
 
 	// Create Assignment Policy
 	accessPackageAssignmentPolicy := testAccessPackageAssignmentPolicyClient_Create(t, c, msgraph.AccessPackageAssignmentPolicy{
@@ -90,7 +87,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 							ODataType:   utils.StringPtr(odata.TypeSingleUser),
 							Description: utils.StringPtr("approver"),
 							IsBackup:    utils.BoolPtr(false),
-							ID:          approver.ID(),
+							ID:          approverUser.ID(),
 						},
 					},
 				},

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -53,6 +53,9 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 		},
 	})
 
+	// Adding a sleep to see if there is an eventual consistency issue with creating a user and applying the user to a policy
+	time.Sleep(time.Second * 30)
+
 	// Create Assignment Policy
 	accessPackageAssignmentPolicy := testAccessPackageAssignmentPolicyClient_Create(t, c, msgraph.AccessPackageAssignmentPolicy{
 		AccessPackageId: accessPackage.ID,
@@ -87,7 +90,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 							ODataType:   utils.StringPtr(odata.TypeSingleUser),
 							Description: utils.StringPtr("approver"),
 							IsBackup:    utils.BoolPtr(false),
-							ID:          approverUser.ID(),
+							ID:          user2.ID(),
 						},
 					},
 				},

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -1,0 +1,108 @@
+package msgraph_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/manicminer/hamilton/internal/test"
+	"github.com/manicminer/hamilton/internal/utils"
+	"github.com/manicminer/hamilton/msgraph"
+)
+
+func TestAccessPackageAssignmentRequestClient(t *testing.T) {
+	c := test.NewTest(t)
+	defer c.CancelFunc()
+
+	// Create test Catalog
+	accessPackageCatalog := testAccessPackageCatalog_Create(t, c)
+
+	// Create AP
+	accessPackage := testAccessPackage_Create(t, c, accessPackageCatalog)
+
+	currentTimePlusDay := time.Now().AddDate(0, 0, 1)
+
+	user := testUsersClient_Create(t, c, msgraph.User{
+		AccountEnabled:    utils.BoolPtr(true),
+		DisplayName:       utils.StringPtr("test-user"),
+		MailNickname:      utils.StringPtr(fmt.Sprintf("test-user-%s", c.RandomString)),
+		UserPrincipalName: utils.StringPtr(fmt.Sprintf("test-user-%s@%s", c.RandomString, c.Connections["default"].DomainName)),
+		PasswordProfile: &msgraph.UserPasswordProfile{
+			Password: utils.StringPtr(fmt.Sprintf("IrPa55w0rd%s", c.RandomString)),
+		},
+	})
+
+	// Create Assignment Policy
+	accessPackageAssignmentPolicy := testAccessPackageAssignmentPolicyClient_Create(t, c, msgraph.AccessPackageAssignmentPolicy{
+		AccessPackageId: accessPackage.ID,
+		AccessReviewSettings: &msgraph.AssignmentReviewSettings{
+			AccessReviewTimeoutBehavior:     msgraph.AccessReviewTimeoutBehaviorTypeRemoveAccess,
+			IsEnabled:                       utils.BoolPtr(true),
+			StartDateTime:                   &currentTimePlusDay,
+			DurationInDays:                  utils.Int32Ptr(5),
+			RecurrenceType:                  msgraph.AccessReviewRecurranceTypeMonthly,
+			ReviewerType:                    msgraph.AccessReviewReviewerTypeSelf,
+			IsAccessRecommendationEnabled:   utils.BoolPtr(true),
+			IsApprovalJustificationRequired: utils.BoolPtr(true),
+		},
+		DisplayName: utils.StringPtr(fmt.Sprintf("Test-AP-Assignment-Request-%s", c.RandomString)),
+		Description: utils.StringPtr("Test AP Policy Assignment Description"),
+		RequestorSettings: &msgraph.RequestorSettings{
+			ScopeType:      msgraph.RequestorSettingsScopeTypeNoSubjects,
+			AcceptRequests: utils.BoolPtr(true),
+		},
+		RequestApprovalSettings: &msgraph.ApprovalSettings{
+			IsApprovalRequired:               utils.BoolPtr(false),
+			IsApprovalRequiredForExtension:   utils.BoolPtr(false),
+			IsRequestorJustificationRequired: utils.BoolPtr(false),
+			ApprovalMode:                     msgraph.ApprovalModeNoApproval,
+		},
+		Questions: &[]msgraph.AccessPackageQuestion{},
+	})
+
+	accessPackageAssignementRequest := msgraph.AccessPackageAssignmentRequest{
+		RequestType: utils.StringPtr(msgraph.AccessPacakgeRequestTypeAdminAdd),
+		AccessPackageAssignment: &msgraph.AccessPackageAssignment{
+			TargetID:            user.ID(),
+			AssignementPolicyID: accessPackageAssignmentPolicy.ID,
+			AccessPackageID:     accessPackage.ID,
+		},
+	}
+
+	ap := testAccessPackageAssignmentRequestClient_Create(t, c, accessPackageAssignementRequest)
+	testAccessPacakgeAssignmentRequestClient_Delete(t, c, *ap.ID)
+
+	//Cleanup
+	testUser_Delete(t, c, user)
+	testAccessPackageAssignmentPolicyClient_Delete(t, c, *accessPackageAssignmentPolicy.ID)
+	testAccessPackage_Delete(t, c, *accessPackage.ID)
+	testAccessPackageCatalog_Delete(t, c, accessPackageCatalog)
+
+}
+
+func testAccessPackageAssignmentRequestClient_Create(t *testing.T, c *test.Test, ar msgraph.AccessPackageAssignmentRequest) (request *msgraph.AccessPackageAssignmentRequest) {
+	request, status, err := c.AccessPackageAssignmentRequestClient.Create(c.Context, ar)
+	if err != nil {
+		t.Fatalf("AccessPackageAssignementRequestClient.Create(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AccessPackageAssignementRequestClient.Create(): invalid status: %d", status)
+	}
+	if request == nil {
+		t.Fatal("AccessPackageAssignementRequestClient.Create(): AccessPackageAssignmentRequest was nil")
+	}
+	if request.ID == nil {
+		t.Fatal("AccessPackageAssignementRequestClient.Create(): AccessPackageAssignmentRequest.ID was nil")
+	}
+	return request
+}
+
+func testAccessPacakgeAssignmentRequestClient_Delete(t *testing.T, c *test.Test, id string) {
+	status, err := c.AccessPackageAssignmentRequestClient.Delete(c.Context, id)
+	if err != nil {
+		t.Fatalf("AccessPackageAssignmentRequestClient.Delete(): %v", err)
+	}
+	if status < 200 || status >= 300 {
+		t.Fatalf("AccessPackageAssignmentRequestClient.Delete(): invalid status: %d", status)
+	}
+}

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -21,7 +21,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 	// Create AP
 	accessPackage := testAccessPackage_Create(t, c, accessPackageCatalog)
 
-	currentTimePlusDay := time.Now().AddDate(0, 0, 1)
+	currentTime := time.Now()
 
 	user := testUsersClient_Create(t, c, msgraph.User{
 		AccountEnabled:    utils.BoolPtr(true),
@@ -59,7 +59,7 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 		AccessReviewSettings: &msgraph.AssignmentReviewSettings{
 			AccessReviewTimeoutBehavior:     msgraph.AccessReviewTimeoutBehaviorTypeRemoveAccess,
 			IsEnabled:                       utils.BoolPtr(true),
-			StartDateTime:                   &currentTimePlusDay,
+			StartDateTime:                   &currentTime,
 			DurationInDays:                  utils.Int32Ptr(5),
 			RecurrenceType:                  msgraph.AccessReviewRecurranceTypeMonthly,
 			ReviewerType:                    msgraph.AccessReviewReviewerTypeSelf,

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/manicminer/hamilton/internal/test"
 	"github.com/manicminer/hamilton/internal/utils"
 	"github.com/manicminer/hamilton/msgraph"
+	"github.com/manicminer/hamilton/odata"
 )
 
 func TestAccessPackageAssignmentRequestClient(t *testing.T) {
@@ -44,20 +45,104 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 			ReviewerType:                    msgraph.AccessReviewReviewerTypeSelf,
 			IsAccessRecommendationEnabled:   utils.BoolPtr(true),
 			IsApprovalJustificationRequired: utils.BoolPtr(true),
+			// Reviewers: &[]msgraph.UserSet{
+			// 	{
+			// 		ODataType:    utils.StringPtr(odata.TypeRequestorManager),
+			// 		IsBackup:     utils.BoolPtr(false),
+			// 		ManagerLevel: utils.Int32Ptr(1),
+			// 	},
+			// 	{
+			// 		ODataType:    utils.StringPtr(odata.TypeSingleUser),
+			// 		IsBackup:     utils.BoolPtr(true),
+			// 		ID:           utils.StringPtr(""),
+			// 	},
+			// },
 		},
-		DisplayName: utils.StringPtr(fmt.Sprintf("Test-AP-Assignment-Request-%s", c.RandomString)),
+		DisplayName: utils.StringPtr(fmt.Sprintf("Test-AP-Policy-Assignment-%s", c.RandomString)),
 		Description: utils.StringPtr("Test AP Policy Assignment Description"),
+		//AccessReviewSettings: utils.BoolPtr()
 		RequestorSettings: &msgraph.RequestorSettings{
+			//ScopeType:      msgraph.RequestorSettingsScopeTypeSpecificDirectorySubjects,
 			ScopeType:      msgraph.RequestorSettingsScopeTypeNoSubjects,
 			AcceptRequests: utils.BoolPtr(true),
+			// AllowedRequestors: &[]msgraph.UserSet{
+			// 		{
+			// 			ODataType: utils.StringPtr(odata.TypeGroupMembers),
+			// 			IsBackup: utils.BoolPtr(false),
+			// 			ID: utils.StringPtr("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+			// 			Description: utils.StringPtr("Sample users group"),
+			// 		},
+			// },
 		},
 		RequestApprovalSettings: &msgraph.ApprovalSettings{
 			IsApprovalRequired:               utils.BoolPtr(false),
 			IsApprovalRequiredForExtension:   utils.BoolPtr(false),
 			IsRequestorJustificationRequired: utils.BoolPtr(false),
 			ApprovalMode:                     msgraph.ApprovalModeNoApproval,
+			//ApprovalStages: &msgraph.ApprovalStages{},
 		},
-		Questions: &[]msgraph.AccessPackageQuestion{},
+		Questions: &[]msgraph.AccessPackageQuestion{
+			{
+				ODataType:  utils.StringPtr(odata.TypeAccessPackageTextInputQuestion),
+				IsRequired: utils.BoolPtr(false),
+				Sequence:   utils.Int32Ptr(1),
+				Text: &msgraph.AccessPackageLocalizedContent{
+					DefaultText: utils.StringPtr("Test"),
+					LocalizedTexts: &[]msgraph.AccessPackageLocalizedTexts{
+						{
+							Text:         utils.StringPtr("abc"),
+							LanguageCode: utils.StringPtr("en"),
+						},
+					},
+				},
+			},
+			{
+				ODataType:  utils.StringPtr(odata.TypeAccessPackageMultipleChoiceQuestion),
+				IsRequired: utils.BoolPtr(false),
+				Sequence:   utils.Int32Ptr(2),
+				Text: &msgraph.AccessPackageLocalizedContent{
+					DefaultText: utils.StringPtr("Test"),
+					LocalizedTexts: &[]msgraph.AccessPackageLocalizedTexts{
+						{
+							Text:         utils.StringPtr("abc 2"),
+							LanguageCode: utils.StringPtr("gb"),
+						},
+					},
+				},
+				Choices: &[]msgraph.AccessPackageMultipleChoiceQuestions{
+					// Choice 1 containing a list of languages
+					{
+						ActualValue: utils.StringPtr("CHOICE1"),
+						DisplayValue: &msgraph.AccessPackageLocalizedContent{
+							DefaultText: utils.StringPtr("One"),
+							LocalizedTexts: &[]msgraph.AccessPackageLocalizedTexts{
+								{
+									Text:         utils.StringPtr("Choice 1"),
+									LanguageCode: utils.StringPtr("gb"),
+								},
+							},
+						},
+					},
+					// Choice 2 containing a list of languages, etc.
+					{
+						ActualValue: utils.StringPtr("CHOICE2"),
+						DisplayValue: &msgraph.AccessPackageLocalizedContent{
+							DefaultText: utils.StringPtr("Two"),
+							LocalizedTexts: &[]msgraph.AccessPackageLocalizedTexts{
+								{
+									Text:         utils.StringPtr("Choice 2"),
+									LanguageCode: utils.StringPtr("gb"),
+								},
+								{
+									Text:         utils.StringPtr("Zwei"),
+									LanguageCode: utils.StringPtr("de"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	})
 
 	// accessPackageAssignementRequest := msgraph.AccessPackageAssignmentRequest{

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -2,7 +2,6 @@ package msgraph_test
 
 import (
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -61,18 +60,23 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 		Questions: &[]msgraph.AccessPackageQuestion{},
 	})
 
-	accessPackageAssignementRequest := msgraph.AccessPackageAssignmentRequest{
+	// accessPackageAssignementRequest := msgraph.AccessPackageAssignmentRequest{
+	// 	RequestType: utils.StringPtr(msgraph.AccessPacakgeRequestTypeAdminAdd),
+	// 	AccessPackageAssignment: &msgraph.AccessPackageAssignment{
+	// 		TargetID:            user.ID(),
+	// 		AssignementPolicyID: accessPackageAssignmentPolicy.ID,
+	// 		AccessPackageID:     accessPackage.ID,
+	// 	},
+	// }
+
+	ap := testAccessPackageAssignmentRequestClient_Create(t, c, msgraph.AccessPackageAssignmentRequest{
 		RequestType: utils.StringPtr(msgraph.AccessPacakgeRequestTypeAdminAdd),
 		AccessPackageAssignment: &msgraph.AccessPackageAssignment{
-			TargetID:            user.ID(),
+			TargetID:            user.Id,
 			AssignementPolicyID: accessPackageAssignmentPolicy.ID,
 			AccessPackageID:     accessPackage.ID,
 		},
-	}
-
-	log.Println(accessPackageAssignementRequest)
-
-	ap := testAccessPackageAssignmentRequestClient_Create(t, c, accessPackageAssignementRequest)
+	})
 	testAccessPacakgeAssignmentRequestClient_Delete(t, c, *ap.ID)
 
 	//Cleanup

--- a/msgraph/accesspackageassignementrequest_test.go
+++ b/msgraph/accesspackageassignementrequest_test.go
@@ -68,8 +68,8 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 			Reviewers: &[]msgraph.UserSet{
 				{
 					ODataType: utils.StringPtr(odata.TypeSingleUser),
-					IsBackup:  utils.BoolPtr(true),
-					ID:        utils.StringPtr(*approverUser.Id),
+					IsBackup:  utils.BoolPtr(false),
+					ID:        approverUser.Id,
 				},
 			},
 		},
@@ -92,8 +92,8 @@ func TestAccessPackageAssignmentRequestClient(t *testing.T) {
 					PrimaryApprovers: &[]msgraph.UserSet{
 						{
 							ODataType: utils.StringPtr(odata.TypeSingleUser),
-							IsBackup:  utils.BoolPtr(true),
-							ID:        utils.StringPtr(*approverUser.Id),
+							IsBackup:  utils.BoolPtr(false),
+							ID:        approverUser.Id,
 						},
 					},
 				},

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -27,6 +27,23 @@ type AccessPackage struct {
 	CreatedBy           *string `json:"createdBy,omitempty"`
 }
 
+type AccessPackageAssignment struct {
+	TargetID            *string `json:"targetId,omitempty"`
+	AssignementPolicyID *string `json:"assignmentPolicyId,omitempty"`
+	AccessPackageID     *string `json:"accessPackageId,omitempty"`
+}
+
+type AccessPackageAssignmentRequest struct {
+	ID                      *string                        `json:"id,omitempty"`
+	RequestType             *AccessPacakgeRequestType      `json:"requestType,omitempty"`
+	Status                  *string                        `json:"status"`
+	CompletedDateTime       *time.Time                     `json:"completedDateTime,omitempty"`
+	CreatedDateTime         *time.Time                     `json:"createdDateTime,omitempty"`
+	State                   *AccessPackageRequestState     `json:"state,omitempty"`
+	Schedule                *EntitlementManagementSchedule `json:"schedule,omitempty"`
+	AccessPackageAssignment *AccessPackageAssignment       `json:"assignment,omitempty"`
+}
+
 type AccessPackageAssignmentPolicy struct {
 	AccessPackageId         *string                   `json:"accessPackageId,omitempty"`
 	AccessReviewSettings    *AssignmentReviewSettings `json:"accessReviewSettings,omitempty"`
@@ -855,9 +872,21 @@ type EmailAuthenticationMethod struct {
 	EmailAddress *string `json:"emailAddress,omitempty"`
 }
 
+type EntitlementManagementSchedule struct {
+	StartDateTime *time.Time         `json:"startDateTime,omitempty"`
+	Expiration    *ExpirationPattern `json:"expiration,omitempty"`
+	Recurrence    *RecurrencePattern `json:"recurrence,omitempty"`
+}
+
 type ExtensionSchemaProperty struct {
 	Name *string                         `json:"name,omitempty"`
 	Type ExtensionSchemaPropertyDataType `json:"type,omitempty"`
+}
+
+type ExpirationPattern struct {
+	Duration    *time.Duration         `json:"duration,omitempty"`
+	EndDateTime *time.Time             `json:"endDateTime,omitempty"`
+	Type        *ExpirationPatternType `json:"type,omitempty"`
 }
 
 type FederatedIdentityCredential struct {
@@ -1258,6 +1287,16 @@ type PublicClient struct {
 
 type Recipient struct {
 	EmailAddress *EmailAddress `json:"emailAddress,omitempty"`
+}
+
+type RecurrencePattern struct {
+	DayOfMonth     *int                   `json:"dayOfMonth,omitempty"`
+	Interval       *int                   `json:"interval,omitempty"`
+	Month          *int                   `json:"month,omitempty"`
+	Type           *RecurrencePatternType `json:"type,omitempty"`
+	DaysOfWeek     *[]DaysOfWeekType      `json:"daysOfWeek,omitempty"`
+	FirstDayOfWeek *FirstDayOfWeek        `json:"firstDayOfWeek,omitempty"`
+	Index          *IndexType             `json:"index,omitempty"`
 }
 
 type Ref struct {

--- a/msgraph/models.go
+++ b/msgraph/models.go
@@ -27,6 +27,11 @@ type AccessPackage struct {
 	CreatedBy           *string `json:"createdBy,omitempty"`
 }
 
+type AccessPackageAnswer struct {
+	DisplayValue     *string                `json:"displayValue,omitempty"`
+	AnsweredQuestion *AccessPackageQuestion `json:"answeredQuestion,omitempty"`
+}
+
 type AccessPackageAssignment struct {
 	TargetID            *string `json:"targetId,omitempty"`
 	AssignementPolicyID *string `json:"assignmentPolicyId,omitempty"`
@@ -34,14 +39,21 @@ type AccessPackageAssignment struct {
 }
 
 type AccessPackageAssignmentRequest struct {
-	ID                      *string                        `json:"id,omitempty"`
-	RequestType             *AccessPacakgeRequestType      `json:"requestType,omitempty"`
-	Status                  *string                        `json:"status"`
-	CompletedDateTime       *time.Time                     `json:"completedDateTime,omitempty"`
-	CreatedDateTime         *time.Time                     `json:"createdDateTime,omitempty"`
-	State                   *AccessPackageRequestState     `json:"state,omitempty"`
-	Schedule                *EntitlementManagementSchedule `json:"schedule,omitempty"`
-	AccessPackageAssignment *AccessPackageAssignment       `json:"assignment,omitempty"`
+	ID                             *string                         `json:"id,omitempty"`
+	RequestType                    *AccessPacakgeRequestType       `json:"requestType,omitempty"`
+	Status                         *string                         `json:"status"`
+	CompletedDateTime              *time.Time                      `json:"completedDateTime,omitempty"`
+	CreatedDateTime                *time.Time                      `json:"createdDateTime,omitempty"`
+	State                          *AccessPackageRequestState      `json:"state,omitempty"`
+	Schedule                       *EntitlementManagementSchedule  `json:"schedule,omitempty"`
+	AccessPackageAssignment        *AccessPackageAssignment        `json:"assignment,omitempty"`
+	CompletedDate                  *time.Time                      `json:"completedDate,omitempty"`                   // beta property
+	IsValidationOnly               *bool                           `json:"isValidationOnly,omitempty"`                // beta property
+	Justification                  *string                         `json:"justification,omitempty"`                   // beta property
+	RequestState                   *AccessPackageRequestState      `json:"requestState,omitempty"`                    // beta property
+	RequestStatus                  *string                         `json:"requestStatus,omitempty"`                   // beta property
+	CustomExtensionHandlerInstance *CustomExtensionHandlerInstance `json:"customExtensionHandlerInstances,omitempty"` // beta property
+	Answers                        *[]AccessPackageAnswer          `json:"answers,omitempty"`                         // beta property
 }
 
 type AccessPackageAssignmentPolicy struct {
@@ -695,6 +707,13 @@ type ConnectedOrganization struct {
 	State            *ConnectedOrganizationState `json:"state,omitempty"`
 	CreatedDateTime  *time.Time                  `json:"createdDateTime,omitempty"`
 	ModifiedDateTime *time.Time                  `json:"modifiedDateTime,omitempty"`
+}
+
+type CustomExtensionHandlerInstance struct {
+	CustomExensionId      *string                                    `json:"customExtensionId,omitempty"`
+	ExternalCorrelationId *string                                    `json:"externalCorrelationId,omitempty"`
+	Stage                 *AccessPackageCustomExtensionStage         `json:"stage,omitempty"`
+	Status                *AccessPackageCustomExtensionHandlerStatus `json:"status,omitempty"`
 }
 
 type DelegatedPermissionGrant struct {

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -43,6 +43,24 @@ const (
 	AccessPackageCatalogTypeUserManaged    AccessPackageCatalogType = "UserManaged"
 )
 
+type AccessPackageCustomExtensionStage = string
+
+const (
+	AccessPackageCustomExtensionStageAssignmentRequestCreated               AccessPackageCustomExtensionStage = "assignmentRequestCreated"
+	AccessPackageCustomExtensionStageAssignmentRequestApproved              AccessPackageCustomExtensionStage = "assignmentRequestApproved"
+	AccessPackageCustomExtensionStageAssignmentRequestGranted               AccessPackageCustomExtensionStage = "assignmentRequestGranted"
+	AccessPackageCustomExtensionStageAssignmentRequestRemoved               AccessPackageCustomExtensionStage = "assignmentRequestRemoved"
+	AccessPackageCustomExtensionStageAssignmentFourteenDaysBeforeExpiration AccessPackageCustomExtensionStage = "assignmentFourteenDaysBeforeExpiration"
+	AccessPackageCustomExtensionStageAssignmentOneDayBeforeExpiration       AccessPackageCustomExtensionStage = "assignmentOneDayBeforeExpiration"
+)
+
+type AccessPackageCustomExtensionHandlerStatus = string
+
+const (
+	AccessPackageCustomExtensionHandlerStatusRequestSent     AccessPackageCustomExtensionHandlerStatus = "requestSent"
+	AccessPackageCustomExtensionHandlerStatusRequestReceived AccessPackageCustomExtensionHandlerStatus = "requestReceived"
+)
+
 type AccessPackageRequestState = string
 
 const (

--- a/msgraph/valuetypes.go
+++ b/msgraph/valuetypes.go
@@ -43,6 +43,37 @@ const (
 	AccessPackageCatalogTypeUserManaged    AccessPackageCatalogType = "UserManaged"
 )
 
+type AccessPackageRequestState = string
+
+const (
+	AccessPackageRequestStateSubmitted           AccessPackageRequestState = "submitted"
+	AccessPackageRequestStatePendingApproval     AccessPackageRequestState = "pendingApproval"
+	AccessPackageRequestStateDelivering          AccessPackageRequestState = "delivering"
+	AccessPackageRequestStateDelivered           AccessPackageRequestState = "delievered"
+	AccessPackageRequestStateDeliveryFailed      AccessPackageRequestState = "deliveryFailed"
+	AccessPackageRequestStateDenied              AccessPackageRequestState = "denied"
+	AccessPackageRequestStateScheduled           AccessPackageRequestState = "scheduled"
+	AccessPackageRequestStateCanceled            AccessPackageRequestState = "canceled"
+	AccessPackageRequestStatePartiallyDelievered AccessPackageRequestState = "partiallyDelivered"
+)
+
+type AccessPacakgeRequestType = string
+
+const (
+	AccessPacakgeRequestTypeNotSpecified AccessPacakgeRequestType = "notSpecified"
+	AccessPacakgeRequestTypeuserAdd      AccessPacakgeRequestType = "userAdd"
+	AccessPacakgeRequestTypeUserExtend   AccessPacakgeRequestType = "UserExtend"
+	AccessPacakgeRequestTypeUserUpdate   AccessPacakgeRequestType = "userUpdate"
+	AccessPacakgeRequestTypeUserRemove   AccessPacakgeRequestType = "userRemove"
+	AccessPacakgeRequestTypeAdminAdd     AccessPacakgeRequestType = "adminAdd"
+	AccessPacakgeRequestTypeAdminUpdate  AccessPacakgeRequestType = "adminUpdate"
+	AccessPacakgeRequestTypeAdminRemove  AccessPacakgeRequestType = "adminRemove"
+	AccessPacakgeRequestTypeSystemAdd    AccessPacakgeRequestType = "systemAdd"
+	AccessPacakgeRequestTypeSystemUpdate AccessPacakgeRequestType = "systemUpdate"
+	AccessPacakgeRequestTypeSystemRemove AccessPacakgeRequestType = "systemRemove"
+	AccessPacakgeRequestTypeOnBehalfAdd  AccessPacakgeRequestType = "onBehalfAdd"
+)
+
 type AccessPackageResourceOriginSystem = string
 
 const (
@@ -327,11 +358,32 @@ const (
 	ConnectedOrganizationStateUnknownFutureValue ConnectedOrganizationState = "unknownFutureValue"
 )
 
+type DaysOfWeekType = string
+
+const (
+	DaysOfWeekTypeSunday    DaysOfWeekType = "sunday"
+	DaysOfWeekTypeMonday    DaysOfWeekType = "monday"
+	DaysOfWeekTypeTuesday   DaysOfWeekType = "tuesday"
+	DaysOfWeekTypeWednesday DaysOfWeekType = "wednesday"
+	DaysOfWeekTypeThursday  DaysOfWeekType = "thursday"
+	DaysOfWeekTypeFriday    DaysOfWeekType = "friday"
+	DaysOfWeekTypeSaturday  DaysOfWeekType = "saturday"
+)
+
 type DelegatedPermissionGrantConsentType = string
 
 const (
 	DelegatedPermissionGrantConsentTypeAllPrincipals DelegatedPermissionGrantConsentType = "AllPrincipals"
 	DelegatedPermissionGrantConsentTypePrincipal     DelegatedPermissionGrantConsentType = "Principal"
+)
+
+type ExpirationPatternType = string
+
+const (
+	ExpirationPatternTypeNotSpecified  ExpirationPatternType = "notSpecified"
+	ExpirationPatternTypeNoExpiration  ExpirationPatternType = "noExpiration"
+	ExpirationPatternTypeAfterDateTime ExpirationPatternType = "afterDateTime"
+	ExpirationPatternTypeAfterDuration ExpirationPatternType = "afterDuration"
 )
 
 type ExtensionSchemaTargetType = string
@@ -364,6 +416,18 @@ const (
 	FeatureTypeRegistration       FeatureType = "registration"
 	FeatureTypeReset              FeatureType = "reset"
 	FeatureTypeUnknownFutureValue FeatureType = "unknownFutureValue"
+)
+
+type FirstDayOfWeek = string
+
+const (
+	FirstDayOfWeekSunday    FirstDayOfWeek = "sunday"
+	FirstDayOfWeekMonday    FirstDayOfWeek = "monday"
+	FirstDayOfWeekTuesday   FirstDayOfWeek = "tuesday"
+	FirstDayOfWeekWednesday FirstDayOfWeek = "wednesday"
+	FirstDayOfWeekThursday  FirstDayOfWeek = "thursday"
+	FirstDayOfWeekFriday    FirstDayOfWeek = "friday"
+	FirstDayOfWeekSaturday  FirstDayOfWeek = "staturday"
 )
 
 type GroupMembershipRuleProcessingState = string
@@ -538,6 +602,17 @@ const (
 	PreferredSingleSignOnModeSaml         PreferredSingleSignOnMode = "saml"
 )
 
+type RecurrencePatternType = string
+
+const (
+	RecurrencePatternTypeDaily           RecurrencePatternType = "daily"
+	RecurrencePatternTypeWeekly          RecurrencePatternType = "weekly"
+	RecurrencePatternTypeAbsoluteMonthly RecurrencePatternType = "absoluteMonthly"
+	RecurrencePatternTypeRelativeMonthly RecurrencePatternType = "relativeMonthly"
+	RecurrencePatternTypeAbsoluteYearly  RecurrencePatternType = "absoluteYearly"
+	RecurrencePatternTypeRelativeYearly  RecurrencePatternType = "relativeYearly"
+)
+
 type RegistrationAuthMethod = string
 
 const (
@@ -650,4 +725,14 @@ const (
 	UserflowAttributeDataTypeString  UserflowAttributeDataType = "string"
 	UserflowAttributeDataTypeBoolean UserflowAttributeDataType = "boolean"
 	UserflowAttributeDataTypeInt64   UserflowAttributeDataType = "int64"
+)
+
+type IndexType = string
+
+const (
+	IndexTypeFirst  IndexType = "first"
+	IndexTypeSecond IndexType = "second"
+	IndexTypeThird  IndexType = "third"
+	IndexTypeFourth IndexType = "fourth"
+	IndexTypeLast   IndexType = "last"
 )


### PR DESCRIPTION
Adds support for MS Graph Entitlement management access package assignment requests. 

This PR creates the required client and the following methods:

* [Create](https://learn.microsoft.com/en-us/graph/api/entitlementmanagement-post-assignmentrequests?view=graph-rest-1.0&tabs=http)
* [Get](https://learn.microsoft.com/en-us/graph/api/accesspackageassignmentrequest-get?view=graph-rest-1.0&tabs=http)
* [List](https://learn.microsoft.com/en-us/graph/api/entitlementmanagement-list-assignmentrequests?view=graph-rest-1.0&tabs=http)
* [Cancel](https://learn.microsoft.com/en-us/graph/api/accesspackageassignmentrequest-cancel?view=graph-rest-1.0&tabs=http)
* [Reprocess](https://learn.microsoft.com/en-us/graph/api/accesspackageassignmentrequest-reprocess?view=graph-rest-1.0)
* [Delete](https://learn.microsoft.com/en-us/graph/api/accesspackageassignmentrequest-delete?view=graph-rest-1.0&tabs=http)

I've created the model so it supports both [V1.0](https://learn.microsoft.com/en-us/graph/api/resources/accesspackageassignmentrequest?view=graph-rest-1.0) and [beta](https://learn.microsoft.com/en-us/graph/api/resources/accesspackageassignmentrequest?view=graph-rest-beta)

I've added tests where possible. I'm unable to test Reprocess as this can only be used when azure has a failure which we cannot simulate. 